### PR TITLE
Don't escape tags that contain dashed and underscore

### DIFF
--- a/ext/generate.c
+++ b/ext/generate.c
@@ -864,7 +864,7 @@ maybe_tag_or_link(MMIOT *f)
 	}
 	else if ( isspace(c) )
 	    break;
-	else if ( ! (c == '/' || isalnum(c) ) )
+	else if ( ! (c == '/' || c == '-' || c == '_' || isalnum(c) ) )
 	    maybetag=0;
     }
 

--- a/test/rdiscount_test.rb
+++ b/test/rdiscount_test.rb
@@ -103,4 +103,9 @@ EOS
     rd = RDiscount.new("[foo](id:bar)", :no_pseudo_protocols)
     assert_equal "<p>[foo](id:bar)</p>\n", rd.to_html
   end
+
+  def test_that_tags_can_have_dashes_and_underscores
+    rd = RDiscount.new("foo <asdf-qwerty>bar</asdf-qwerty> and <a_b>baz</a_b>")
+    assert_equal "<p>foo <asdf-qwerty>bar</asdf-qwerty> and <a_b>baz</a_b></p>\n", rd.to_html
+  end
 end


### PR DESCRIPTION
Kind of an edge case scenario here, but we have some custom tags that later get processed by nokogiri, but they start their life in markdown... These tags have dashes in them, and since that's valid tag syntax, I made this tiny patch to rdiscount.
