### PR TITLE
As of Rubygems 1.7.0, `Gem::Specification#has_rdoc=` has been deprecated

### DIFF
--- a/rdiscount.gemspec
+++ b/rdiscount.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.date = '2011-01-25'
   s.email = 'rtomayko@gmail.com'
   s.homepage = 'http://github.com/rtomayko/rdiscount'
-  s.has_rdoc = true
   s.authors = ["Ryan Tomayko", "David Loren Parsons", "Andrew White"]
   # = MANIFEST =
   s.files = %w[


### PR DESCRIPTION
`has_rdoc=` has been deprecated (see http://blog.segment7.net/2011/04/01/rubygems-1-7-0 for example). So it's better to remove it to avoid future breakage.
