### PR TITLE
KISS: be a thinner layer over the Discount library

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ task 'test:conformance' => [:build] do |t|
   test_version = ENV['MARKDOWN_TEST_VER'] || '1.0.3'
   lib_dir = "#{pwd}/lib"
   chdir("test/MarkdownTest_#{test_version}") do
-    sh "RUBYLIB=#{lib_dir} ./MarkdownTest.pl --script='#{script}' --tidy"
+    sh "env RDISCOUNT_EXTENSIONS='MKD_NOPANTS' RUBYLIB=#{lib_dir} ./MarkdownTest.pl --script='#{script}' --tidy"
   end
 end
 

--- a/bin/rdiscount
+++ b/bin/rdiscount
@@ -1,7 +1,12 @@
 #!/usr/bin/env ruby
-# Usage: rdiscount [<file>...]
-# Convert one or more Markdown files to HTML and write to standard output. With
-# no <file> or when <file> is '-', read Markdown source text from standard input.
+#
+# Usage: [env RDISCOUNT_EXTENSIONS='<extension>,...'] rdiscount [<file>...]
+#
+# Convert one or more Markdown files to HTML and write to standard output.
+# With no <file> or when <file> is '-', read Markdown source text from
+# standard input.  Optionally, the RDISCOUNT_EXTENSIONS environment variable
+# can specify a comma-separated list of extensions to enable in RDiscount.
+#
 if ARGV.include?('--help')
   File.read(__FILE__).split("\n").grep(/^# /).each do |line|
     puts line[2..-1]
@@ -10,4 +15,5 @@ if ARGV.include?('--help')
 end
 
 require 'rdiscount'
-STDOUT.write(RDiscount.new(ARGF.read).to_html)
+extensions = ENV['RDISCOUNT_EXTENSIONS'].to_s.split(',')
+STDOUT.write(RDiscount.new(ARGF.read, *extensions).to_html)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,13 +7,8 @@ HAVE_SRANDOM = have_func('srandom')
 HAVE_RAND = have_func('rand')
 HAVE_SRAND = have_func('srand')
 
-def sized_int(size, types)
-  types.find { |type| check_sizeof(type) == 4 } ||
-    abort("no int with size #{size}")
-end
-
-DWORD = sized_int(4, ["unsigned long", "unsigned int"])
-WORD =  sized_int(2, ["unsigned int", "unsigned short"])
+DWORD = "unsigned long"
+WORD =  "unsigned short"
 BYTE = "unsigned char"
 
 $defs.push("-DDWORD='#{DWORD}'")

--- a/ext/rdiscount.c
+++ b/ext/rdiscount.c
@@ -71,57 +71,34 @@ rb_rdiscount_toc_content(int argc, VALUE *argv, VALUE self)
 
 int rb_rdiscount__get_flags(VALUE ruby_obj)
 {
-  /* compile flags */
-  int flags = MKD_TABSTOP | MKD_NOHEADER;
-
-  /* smart */
-  if ( rb_funcall(ruby_obj, rb_intern("smart"), 0) != Qtrue )
-      flags = flags | MKD_NOPANTS;
-
-  /* filter_html */
-  if ( rb_funcall(ruby_obj, rb_intern("filter_html"), 0) == Qtrue )
-      flags = flags | MKD_NOHTML;
-
-  /* generate_toc */
-  if ( rb_funcall(ruby_obj, rb_intern("generate_toc"), 0) == Qtrue)
-    flags = flags | MKD_TOC;
-
-  /* no_image */
-  if ( rb_funcall(ruby_obj, rb_intern("no_image"), 0) == Qtrue)
-    flags = flags | MKD_NOIMAGE;
-
-  /* no_links */
-  if ( rb_funcall(ruby_obj, rb_intern("no_links"), 0) == Qtrue)
-    flags = flags | MKD_NOLINKS;
-
-  /* no_tables */
-  if ( rb_funcall(ruby_obj, rb_intern("no_tables"), 0) == Qtrue)
-    flags = flags | MKD_NOTABLES;
-
-  /* strict */
-  if ( rb_funcall(ruby_obj, rb_intern("strict"), 0) == Qtrue)
-    flags = flags | MKD_STRICT;
-
-  /* autolink */
-  if ( rb_funcall(ruby_obj, rb_intern("autolink"), 0) == Qtrue)
-    flags = flags | MKD_AUTOLINK;
-
-  /* safelink */
-  if ( rb_funcall(ruby_obj, rb_intern("safelink"), 0) == Qtrue)
-    flags = flags | MKD_SAFELINK;
-
-  /* no_pseudo_protocols */
-  if ( rb_funcall(ruby_obj, rb_intern("no_pseudo_protocols"), 0) == Qtrue)
-    flags = flags | MKD_NO_EXT;
-
-
-  return flags;
+    VALUE flags = rb_funcall(ruby_obj, rb_intern("flags"), 0);
+    return NUM2INT(rb_funcall(flags, rb_intern("to_i"), 0));
 }
-
 
 void Init_rdiscount()
 {
     rb_cRDiscount = rb_define_class("RDiscount", rb_cObject);
+    rb_define_const(rb_cRDiscount, "MKD_NOLINKS", INT2NUM(MKD_NOLINKS));
+    rb_define_const(rb_cRDiscount, "MKD_NOIMAGE", INT2NUM(MKD_NOIMAGE));
+    rb_define_const(rb_cRDiscount, "MKD_NOPANTS", INT2NUM(MKD_NOPANTS));
+    rb_define_const(rb_cRDiscount, "MKD_NOHTML", INT2NUM(MKD_NOHTML));
+    rb_define_const(rb_cRDiscount, "MKD_STRICT", INT2NUM(MKD_STRICT));
+    rb_define_const(rb_cRDiscount, "MKD_TAGTEXT", INT2NUM(MKD_TAGTEXT));
+    rb_define_const(rb_cRDiscount, "MKD_NO_EXT", INT2NUM(MKD_NO_EXT));
+    rb_define_const(rb_cRDiscount, "MKD_CDATA", INT2NUM(MKD_CDATA));
+    rb_define_const(rb_cRDiscount, "MKD_NOSUPERSCRIPT", INT2NUM(MKD_NOSUPERSCRIPT));
+    rb_define_const(rb_cRDiscount, "MKD_NORELAXED", INT2NUM(MKD_NORELAXED));
+    rb_define_const(rb_cRDiscount, "MKD_NOTABLES", INT2NUM(MKD_NOTABLES));
+    rb_define_const(rb_cRDiscount, "MKD_NOSTRIKETHROUGH", INT2NUM(MKD_NOSTRIKETHROUGH));
+    rb_define_const(rb_cRDiscount, "MKD_TOC", INT2NUM(MKD_TOC));
+    rb_define_const(rb_cRDiscount, "MKD_1_COMPAT", INT2NUM(MKD_1_COMPAT));
+    rb_define_const(rb_cRDiscount, "MKD_AUTOLINK", INT2NUM(MKD_AUTOLINK));
+    rb_define_const(rb_cRDiscount, "MKD_SAFELINK", INT2NUM(MKD_SAFELINK));
+    rb_define_const(rb_cRDiscount, "MKD_NOHEADER", INT2NUM(MKD_NOHEADER));
+    rb_define_const(rb_cRDiscount, "MKD_TABSTOP", INT2NUM(MKD_TABSTOP));
+    rb_define_const(rb_cRDiscount, "MKD_NODIVQUOTE", INT2NUM(MKD_NODIVQUOTE));
+    rb_define_const(rb_cRDiscount, "MKD_NOALPHALIST", INT2NUM(MKD_NOALPHALIST));
+    rb_define_const(rb_cRDiscount, "MKD_NODLIST", INT2NUM(MKD_NODLIST));
     rb_define_method(rb_cRDiscount, "to_html", rb_rdiscount_to_html, -1);
     rb_define_method(rb_cRDiscount, "toc_content", rb_rdiscount_toc_content, -1);
 }

--- a/lib/rdiscount.rb
+++ b/lib/rdiscount.rb
@@ -29,64 +29,55 @@ class RDiscount
   # Original Markdown formatted text.
   attr_reader :text
 
-  # Set true to have smarty-like quote translation performed.
-  attr_accessor :smart
+  # Integer containing bit flags for the underlying Discount library.
+  attr_accessor :flags
 
   # Do not output <tt><style></tt> tags included in the source text.
   attr_accessor :filter_styles
-
-  # Do not output any raw HTML included in the source text.
-  attr_accessor :filter_html
 
   # RedCloth compatible line folding -- not used for Markdown but
   # included for compatibility.
   attr_accessor :fold_lines
 
-  # Enable Table Of Contents generation
-  attr_accessor :generate_toc
-
-  # Do not process <tt>![]</tt> and remove <tt><img></tt> tags from the output.
-  attr_accessor :no_image
-
-  # Do not process <tt>[]</tt> and remove <tt><a></tt> tags from the output.
-  attr_accessor :no_links
-
-  # Do not process tables
-  attr_accessor :no_tables
-
-  # Disable superscript and relaxed emphasis processing.
-  attr_accessor :strict
-
-  # Convert URL in links, even if they aren't encased in <tt><></tt>
-  attr_accessor :autolink
-
-  # Don't make hyperlinks from <tt>[][]</tt> links that have unknown URL types.
-  attr_accessor :safelink
-
-  # Do not process pseudo-protocols like <tt>[](id:name)</tt>
-  attr_accessor :no_pseudo_protocols
-
-  # Create a RDiscount Markdown processor. The +text+ argument
-  # should be a string containing Markdown text. Additional arguments may be
-  # supplied to set various processing options:
+  # Create a RDiscount Markdown processor. The +text+ argument should be a
+  # string containing Markdown text. Additional arguments may be supplied to
+  # set various processing options:
   #
-  # * <tt>:smart</tt> - Enable SmartyPants processing.
-  # * <tt>:filter_styles</tt> - Do not output <tt><style></tt> tags.
-  # * <tt>:filter_html</tt> - Do not output any raw HTML tags included in
-  #   the source text.
-  # * <tt>:fold_lines</tt> - RedCloth compatible line folding (not used).
-  # * <tt>:generate_toc</tt> - Enable Table Of Contents generation
-  # * <tt>:no_image</tt> - Do not output any <tt><img></tt> tags.
-  # * <tt>:no_links</tt> - Do not output any <tt><a></tt> tags.
-  # * <tt>:no_tables</tt> - Do not output any tables.
-  # * <tt>:strict</tt> - Disable superscript and relaxed emphasis processing.
-  # * <tt>:autolink</tt> - Greedily urlify links.
-  # * <tt>:safelink</tt> - Do not make links for unknown URL types.
-  # * <tt>:no_pseudo_protocols</tt> - Do not process pseudo-protocols.
+  # * <tt>:filter_styles</tt>       - Do not output <tt><style></tt> tags.
+  # * <tt>:fold_lines</tt>          - RedCloth compatible line folding (not used).
+  # * <tt>:MKD_NOLINKS</tt>         - Don't do link processing, block <a> tags
+  # * <tt>:MKD_NOIMAGE</tt>         - Don't do image processing, block <img>
+  # * <tt>:MKD_NOPANTS</tt>         - Don't run smartypants()
+  # * <tt>:MKD_NOHTML</tt>          - Don't allow raw html through AT ALL
+  # * <tt>:MKD_STRICT</tt>          - Disable SUPERSCRIPT, RELAXED_EMPHASIS
+  # * <tt>:MKD_TAGTEXT</tt>         - Process text inside an html tag; no <em>, no <bold>, no html or [] expansion
+  # * <tt>:MKD_NO_EXT</tt>          - Don't allow pseudo-protocols
+  # * <tt>:MKD_CDATA</tt>           - Generate code for xml ![CDATA[...]]
+  # * <tt>:MKD_NOSUPERSCRIPT</tt>   - No A^B
+  # * <tt>:MKD_NORELAXED</tt>       - Emphasis happens everywhere
+  # * <tt>:MKD_NOTABLES</tt>        - Don't process PHP Markdown Extra tables.
+  # * <tt>:MKD_NOSTRIKETHROUGH</tt> - Forbid ~~strikethrough~~
+  # * <tt>:MKD_TOC</tt>             - Do table-of-contents processing
+  # * <tt>:MKD_1_COMPAT</tt>        - Compatability with MarkdownTest_1.0
+  # * <tt>:MKD_AUTOLINK</tt>        - Make http://foo.com a link even without <>s
+  # * <tt>:MKD_SAFELINK</tt>        - Paranoid check for link protocol
+  # * <tt>:MKD_NOHEADER</tt>        - Don't process document headers
+  # * <tt>:MKD_TABSTOP</tt>         - Expand tabs to 4 spaces
+  # * <tt>:MKD_NODIVQUOTE</tt>      - Forbid >%class% blocks
+  # * <tt>:MKD_NOALPHALIST</tt>     - Forbid alphabetic lists
+  # * <tt>:MKD_NODLIST</tt>         - Forbid definition lists
   #
   def initialize(text, *extensions)
     @text  = text
-    extensions.each { |e| send("#{e}=", true) }
+    @flags = 0
+    extensions.each do |ext|
+      writer = "#{ext}="
+      if respond_to? writer
+        send writer, true
+      else
+        @flags |= RDiscount.const_get(ext)
+      end
+    end
   end
 
 end

--- a/man/rdiscount.1
+++ b/man/rdiscount.1
@@ -1,22 +1,119 @@
-.\" generated with Ronn/v0.6.8
-.\" http://github.com/rtomayko/ronn/
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "RDISCOUNT" "1" "April 2010" "" "RUBY"
+.TH "RDISCOUNT" "1" "July 2011" "" "RUBY"
 .
 .SH "NAME"
 \fBrdiscount\fR \- humane markup to HTML conversion tool
 .
 .SH "SYNOPSIS"
-\fBrdiscount\fR [\fIfile\fR\.\.\.]
+[\fBenv\fR RDISCOUNT_EXTENSIONS=\'\fIextension\fR,\.\.\.\'] \fBrdiscount\fR [\fIfile\fR\.\.\.]
 .
 .SH "DESCRIPTION"
 The \fBrdiscount\fR utility reads one or more markdown(7)\-formatted text \fIfile\fRs and writes HTML to standard output\. With no \fIfile\fR, or when \fIfile\fR is \'\-\', \fBrdiscount\fR reads source text from standard input\.
+.
+.P
+The \fBRDISCOUNT_EXTENSIONS\fR environment variable can specify a comma\-separated list of Markdown processing \fIextension\fRs to enable (see \fBEXTENSIONS\fR below)\.
+.
+.SH "EXTENSIONS"
+.
+.TP
+\fBfilter_styles\fR
+Do not output \fB<style>\fR tags\.
+.
+.TP
+\fBfold_lines\fR
+RedCloth compatible line folding (not used)\.
+.
+.TP
+\fBMKD_NOLINKS\fR
+Don\'t do link processing, block \fB<a>\fR tags
+.
+.TP
+\fBMKD_NOIMAGE\fR
+Don\'t do image processing, block \fB<img>\fR
+.
+.TP
+\fBMKD_NOPANTS\fR
+Don\'t run smartypants()
+.
+.TP
+\fBMKD_NOHTML\fR
+Don\'t allow raw html through AT ALL
+.
+.TP
+\fBMKD_STRICT\fR
+Disable SUPERSCRIPT, RELAXED_EMPHASIS
+.
+.TP
+\fBMKD_TAGTEXT\fR
+Process text inside an html tag; no \fB<em>\fR, no \fB<bold>\fR, no html or [] expansion
+.
+.TP
+\fBMKD_NO_EXT\fR
+Don\'t allow pseudo\-protocols
+.
+.TP
+\fBMKD_CDATA\fR
+Generate code for xml ![CDATA[\.\.\.]]
+.
+.TP
+\fBMKD_NOSUPERSCRIPT\fR
+No A
+.
+.TP
+\fBMKD_NORELAXED\fR
+Emphasis happens everywhere
+.
+.TP
+\fBMKD_NOTABLES\fR
+Don\'t process PHP Markdown Extra tables\.
+.
+.TP
+\fBMKD_NOSTRIKETHROUGH\fR
+Forbid
+.
+.TP
+\fBMKD_TOC\fR
+Do table\-of\-contents processing
+.
+.TP
+\fBMKD_1_COMPAT\fR
+Compatability with MarkdownTest_1\.0
+.
+.TP
+\fBMKD_AUTOLINK\fR
+Make http://foo\.com a link even without \fB<>\fRs
+.
+.TP
+\fBMKD_SAFELINK\fR
+Paranoid check for link protocol
+.
+.TP
+\fBMKD_NOHEADER\fR
+Don\'t process document headers
+.
+.TP
+\fBMKD_TABSTOP\fR
+Expand tabs to 4 spaces
+.
+.TP
+\fBMKD_NODIVQUOTE\fR
+Forbid >%class% blocks
+.
+.TP
+\fBMKD_NOALPHALIST\fR
+Forbid alphabetic lists
+.
+.TP
+\fBMKD_NODLIST\fR
+Forbid definition lists
 .
 .SH "RETURN VALUES"
 The \fBrdiscount\fR utility exits 0 on success, and > 0 if an error occurs\.
 .
 .SH "SEE ALSO"
-markdown(7)
+markdown(7), env(1)
 .
 .SH "AUTHOR"
 Ryan Tomayko \fIhttp://tomayko\.com/about\fR

--- a/man/rdiscount.1.ronn
+++ b/man/rdiscount.1.ronn
@@ -3,7 +3,7 @@ rdiscount(1) -- humane markup to HTML conversion tool
 
 ## SYNOPSIS
 
-`rdiscount` [<file>...]
+[`env` RDISCOUNT_EXTENSIONS='<extension>,...'] `rdiscount` [<file>...]
 
 ## DESCRIPTION
 
@@ -11,13 +11,87 @@ The `rdiscount` utility reads one or more markdown(7)-formatted text <file>s and
 writes HTML to standard output. With no <file>, or when <file> is '-',
 `rdiscount` reads source text from standard input.
 
+The `RDISCOUNT_EXTENSIONS` environment variable can specify a comma-separated
+list of Markdown processing <extension>s to enable (see **EXTENSIONS** below).
+
+## EXTENSIONS
+
+* `filter_styles`:
+   Do not output `<style>` tags.
+
+* `fold_lines`:
+   RedCloth compatible line folding (not used).
+
+* `MKD_NOLINKS`:
+   Don't do link processing, block `<a>` tags
+
+* `MKD_NOIMAGE`:
+   Don't do image processing, block `<img>`
+
+* `MKD_NOPANTS`:
+   Don't run smartypants()
+
+* `MKD_NOHTML`:
+   Don't allow raw html through AT ALL
+
+* `MKD_STRICT`:
+   Disable SUPERSCRIPT, RELAXED_EMPHASIS
+
+* `MKD_TAGTEXT`:
+   Process text inside an html tag; no `<em>`, no `<bold>`, no html or [] expansion
+
+* `MKD_NO_EXT`:
+   Don't allow pseudo-protocols
+
+* `MKD_CDATA`:
+   Generate code for xml ![CDATA[...]]
+
+* `MKD_NOSUPERSCRIPT`:
+   No A^B
+
+* `MKD_NORELAXED`:
+   Emphasis happens everywhere
+
+* `MKD_NOTABLES`:
+   Don't process PHP Markdown Extra tables.
+
+* `MKD_NOSTRIKETHROUGH`:
+   Forbid ~~strikethrough~~
+
+* `MKD_TOC`:
+   Do table-of-contents processing
+
+* `MKD_1_COMPAT`:
+   Compatability with MarkdownTest_1.0
+
+* `MKD_AUTOLINK`:
+   Make http://foo.com a link even without `<>`s
+
+* `MKD_SAFELINK`:
+   Paranoid check for link protocol
+
+* `MKD_NOHEADER`:
+   Don't process document headers
+
+* `MKD_TABSTOP`:
+   Expand tabs to 4 spaces
+
+* `MKD_NODIVQUOTE`:
+   Forbid >%class% blocks
+
+* `MKD_NOALPHALIST`:
+   Forbid alphabetic lists
+
+* `MKD_NODLIST`:
+   Forbid definition lists
+
 ## RETURN VALUES
 
 The `rdiscount` utility exits 0 on success, and > 0 if an error occurs.
 
 ## SEE ALSO
 
-markdown(7)
+markdown(7), env(1)
 
 ## AUTHOR
 

--- a/test/markdown_test.rb
+++ b/test/markdown_test.rb
@@ -14,88 +14,88 @@ class MarkdownTest < Test::Unit::TestCase
   end
 
   def test_that_simple_one_liner_goes_to_html
-    markdown = Markdown.new('Hello World.')
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS)
     assert_respond_to markdown, :to_html
     assert_equal "<p>Hello World.</p>", markdown.to_html.strip
   end
 
   def test_that_inline_markdown_goes_to_html
-    markdown = Markdown.new('_Hello World_!')
+    markdown = Markdown.new('_Hello World_!', :MKD_NOPANTS)
     assert_equal "<p><em>Hello World</em>!</p>", markdown.to_html.strip
   end
 
   def test_that_inline_markdown_starts_and_ends_correctly
-    markdown = Markdown.new('_start _ foo_bar bar_baz _ end_ *italic* **bold** <a>_blah_</a>')
+    markdown = Markdown.new('_start _ foo_bar bar_baz _ end_ *italic* **bold** <a>_blah_</a>', :MKD_NOPANTS)
     assert_respond_to markdown, :to_html
     assert_equal "<p><em>start _ foo_bar bar_baz _ end</em> <em>italic</em> <strong>bold</strong> <a><em>blah</em></a></p>", markdown.to_html.strip
 
-    markdown = Markdown.new("Run 'rake radiant:extensions:rbac_base:migrate'")
+    markdown = Markdown.new("Run 'rake radiant:extensions:rbac_base:migrate'", :MKD_NOPANTS)
     assert_equal "<p>Run 'rake radiant:extensions:rbac_base:migrate'</p>", markdown.to_html.strip
   end
 
   def test_that_filter_html_works
-    markdown = Markdown.new('Through <em>NO</em> <script>DOUBLE NO</script>', :filter_html)
+    markdown = Markdown.new('Through <em>NO</em> <script>DOUBLE NO</script>', :MKD_NOPANTS, :MKD_NOHTML)
     assert_equal "<p>Through &lt;em>NO&lt;/em> &lt;script>DOUBLE NO&lt;/script></p>", markdown.to_html.strip
   end
 
   def test_that_bluecloth_restrictions_are_supported
-    markdown = Markdown.new('Hello World.')
-    [:filter_html, :filter_styles].each do |restriction|
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS)
+    [:filter_styles].each do |restriction|
       assert_respond_to markdown, restriction
       assert_respond_to markdown, "#{restriction}="
     end
-    assert_not_equal true, markdown.filter_html
+    assert_not_equal RDiscount::MKD_NOHTML, markdown.flags & RDiscount::MKD_NOHTML
     assert_not_equal true, markdown.filter_styles
 
-    markdown = Markdown.new('Hello World.', :filter_html, :filter_styles)
-    assert_equal true, markdown.filter_html
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS, :MKD_NOHTML, :filter_styles)
+    assert_equal RDiscount::MKD_NOHTML, markdown.flags & RDiscount::MKD_NOHTML
     assert_equal true, markdown.filter_styles
   end
 
   def test_that_redcloth_attributes_are_supported
-    markdown = Markdown.new('Hello World.')
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS)
     assert_respond_to markdown, :fold_lines
     assert_respond_to markdown, :fold_lines=
     assert_not_equal true, markdown.fold_lines
 
-    markdown = Markdown.new('Hello World.', :fold_lines)
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS, :fold_lines)
     assert_equal true, markdown.fold_lines
   end
 
   def test_that_redcloth_to_html_with_single_arg_is_supported
-    markdown = Markdown.new('Hello World.')
+    markdown = Markdown.new('Hello World.', :MKD_NOPANTS)
     assert_nothing_raised(ArgumentError) { markdown.to_html(true) }
   end
 
   def test_that_smart_converts_single_quotes_in_words_that_end_in_re
-    markdown = Markdown.new("They're not for sale.", :smart)
+    markdown = Markdown.new("They're not for sale.")
     assert_equal "<p>They&rsquo;re not for sale.</p>\n", markdown.to_html
   end
 
   def test_that_smart_converts_single_quotes_in_words_that_end_in_ll
-    markdown = Markdown.new("Well that'll be the day", :smart)
+    markdown = Markdown.new("Well that'll be the day")
     assert_equal "<p>Well that&rsquo;ll be the day</p>\n", markdown.to_html
   end
 
   def test_that_urls_are_not_doubly_escaped
-    markdown = Markdown.new('[Page 2](/search?query=Markdown+Test&page=2)')
+    markdown = Markdown.new('[Page 2](/search?query=Markdown+Test&page=2)', :MKD_NOPANTS)
     assert_equal "<p><a href=\"/search?query=Markdown+Test&amp;page=2\">Page 2</a></p>\n", markdown.to_html
   end
 
   def test_simple_inline_html
-    markdown = Markdown.new("before\n\n<div>\n  foo\n</div>\nafter")
+    markdown = Markdown.new("before\n\n<div>\n  foo\n</div>\nafter", :MKD_NOPANTS)
     assert_equal "<p>before</p>\n\n<div>\n  foo\n</div>\n\n\n<p>after</p>\n",
       markdown.to_html
   end
 
   def test_that_html_blocks_do_not_require_their_own_end_tag_line
-    markdown = Markdown.new("Para 1\n\n<div><pre>HTML block\n</pre></div>\n\nPara 2 [Link](#anchor)")
+    markdown = Markdown.new("Para 1\n\n<div><pre>HTML block\n</pre></div>\n\nPara 2 [Link](#anchor)", :MKD_NOPANTS)
     assert_equal "<p>Para 1</p>\n\n<div><pre>HTML block\n</pre></div>\n\n\n<p>Para 2 <a href=\"#anchor\">Link</a></p>\n",
       markdown.to_html
   end
 
   def test_filter_html_doesnt_break_two_space_hard_break
-    markdown = Markdown.new("Lorem,  \nipsum\n", :filter_html)
+    markdown = Markdown.new("Lorem,  \nipsum\n", :MKD_NOPANTS, :MKD_NOHTML)
     assert_equal "<p>Lorem,<br/>\nipsum</p>\n",
       markdown.to_html
   end
@@ -104,7 +104,8 @@ class MarkdownTest < Test::Unit::TestCase
   def test_block_quotes_preceded_by_spaces
     markdown = Markdown.new(
       "A wise man once said:\n\n" +
-      " > Isn't it wonderful just to be alive.\n"
+      " > Isn't it wonderful just to be alive.\n",
+      :MKD_NOPANTS
     )
     assert_equal "<p>A wise man once said:</p>\n\n" +
       "<blockquote><p>Isn't it wonderful just to be alive.</p></blockquote>\n",
@@ -112,13 +113,13 @@ class MarkdownTest < Test::Unit::TestCase
   end
 
   def test_ul_with_zero_space_indent
-    markdown = Markdown.new("- foo\n\n- bar\n\n  baz\n")
+    markdown = Markdown.new("- foo\n\n- bar\n\n  baz\n", :MKD_NOPANTS)
     assert_equal "<ul><li><p>foo</p></li><li><p>bar</p><p>baz</p></li></ul>",
       markdown.to_html.gsub("\n", "")
   end
 
   def test_ul_with_single_space_indent
-    markdown = Markdown.new(" - foo\n\n - bar\n\n   baz\n")
+    markdown = Markdown.new(" - foo\n\n - bar\n\n   baz\n", :MKD_NOPANTS)
     assert_equal "<ul><li><p>foo</p></li><li><p>bar</p><p>baz</p></li></ul>",
       markdown.to_html.gsub("\n", "")
   end
@@ -128,7 +129,7 @@ class MarkdownTest < Test::Unit::TestCase
     text = "The Ant-Sugar Tales \n"         +
            "=================== \n\n"        +
            "By Candice Yellowflower   \n"
-    markdown = Markdown.new(text)
+    markdown = Markdown.new(text, :MKD_NOPANTS)
     assert_equal "<h1>The Ant-Sugar Tales </h1>\n\n<p>By Candice Yellowflower</p>\n",
       markdown.to_html
   end
@@ -142,13 +143,13 @@ class MarkdownTest < Test::Unit::TestCase
     method_name = basename.gsub(/[-,()]/, '').gsub(/\s+/, '_').downcase
 
     define_method "test_#{method_name}" do
-      markdown = Markdown.new(File.read(text_file))
+      markdown = Markdown.new(File.read(text_file), :MKD_NOPANTS)
       actual_html = markdown.to_html
       assert_not_nil actual_html
     end
 
     define_method "test_#{method_name}_smart" do
-      markdown = Markdown.new(File.read(text_file), :smart)
+      markdown = Markdown.new(File.read(text_file))
       actual_html = markdown.to_html
       assert_not_nil actual_html
     end

--- a/test/rdiscount_test.rb
+++ b/test/rdiscount_test.rb
@@ -12,47 +12,47 @@ class RDiscountTest < Test::Unit::TestCase
 
     1.
     TEXT
-    RDiscount.new(text).to_html
+    RDiscount.new(text, :MKD_NOPANTS).to_html
   end
 
   def test_that_smart_converts_double_quotes_to_curly_quotes
-    rd = RDiscount.new(%("Quoted text"), :smart)
+    rd = RDiscount.new(%("Quoted text"))
     assert_equal %(<p>&ldquo;Quoted text&rdquo;</p>\n), rd.to_html
   end
 
   def test_that_smart_converts_double_quotes_to_curly_quotes_before_a_heading
-    rd = RDiscount.new(%("Quoted text"\n\n# Heading), :smart)
+    rd = RDiscount.new(%("Quoted text"\n\n# Heading))
     assert_equal %(<p>&ldquo;Quoted text&rdquo;</p>\n\n<h1>Heading</h1>\n), rd.to_html
   end
 
   def test_that_smart_converts_double_quotes_to_curly_quotes_after_a_heading
-    rd = RDiscount.new(%(# Heading\n\n"Quoted text"), :smart)
+    rd = RDiscount.new(%(# Heading\n\n"Quoted text"))
     assert_equal %(<h1>Heading</h1>\n\n<p>&ldquo;Quoted text&rdquo;</p>\n), rd.to_html
   end
 
   def test_that_smart_gives_ve_suffix_a_rsquo
-    rd = RDiscount.new("I've been meaning to tell you ..", :smart)
+    rd = RDiscount.new("I've been meaning to tell you ..")
     assert_equal "<p>I&rsquo;ve been meaning to tell you ..</p>\n", rd.to_html
   end
 
   def test_that_smart_gives_m_suffix_a_rsquo
-    rd = RDiscount.new("I'm not kidding", :smart)
+    rd = RDiscount.new("I'm not kidding")
     assert_equal "<p>I&rsquo;m not kidding</p>\n", rd.to_html
   end
 
   def test_that_smart_gives_d_suffix_a_rsquo
-    rd = RDiscount.new("what'd you say?", :smart)
+    rd = RDiscount.new("what'd you say?")
     assert_equal "<p>what&rsquo;d you say?</p>\n", rd.to_html
   end
 
   def test_that_generate_toc_sets_toc_ids
-    rd = RDiscount.new("# Level 1\n\n## Level 2", :generate_toc)
-    assert rd.generate_toc
+    rd = RDiscount.new("# Level 1\n\n## Level 2", :MKD_NOPANTS, :MKD_TOC)
+    assert_equal RDiscount::MKD_TOC, rd.flags & RDiscount::MKD_TOC
     assert_equal %(<a name="Level.1"></a>\n<h1>Level 1</h1>\n\n<a name="Level.2"></a>\n<h2>Level 2</h2>\n), rd.to_html
   end
 
   def test_should_get_the_generated_toc
-    rd = RDiscount.new("# Level 1\n\n## Level 2", :generate_toc)
+    rd = RDiscount.new("# Level 1\n\n## Level 2", :MKD_NOPANTS, :MKD_TOC)
     exp = %(<ul>\n <li><a href="#Level.1">Level 1</a></li>\n <li><ul>\n  <li><a href="#Level.2">Level 2</a></li>\n </ul></li>\n</ul>)
     assert_equal exp, rd.toc_content.strip
   end
@@ -66,17 +66,17 @@ class RDiscountTest < Test::Unit::TestCase
   end
 
   def test_that_no_image_flag_works
-    rd = RDiscount.new(%(![dust mite](http://dust.mite/image.png) <img src="image.png" />), :no_image)
+    rd = RDiscount.new(%(![dust mite](http://dust.mite/image.png) <img src="image.png" />), :MKD_NOPANTS, :MKD_NOIMAGE)
     assert rd.to_html !~ /<img/
   end
 
   def test_that_no_links_flag_works
-    rd = RDiscount.new(%([This link](http://example.net/) <a href="links.html">links</a>), :no_links)
+    rd = RDiscount.new(%([This link](http://example.net/) <a href="links.html">links</a>), :MKD_NOPANTS, :MKD_NOLINKS)
     assert rd.to_html !~ /<a /
   end
 
   def test_that_no_tables_flag_works
-    rd = RDiscount.new(<<EOS, :no_tables)
+    rd = RDiscount.new(<<EOS, :MKD_NOPANTS, :MKD_NOTABLES)
  aaa | bbbb
 -----|------
 hello|sailor
@@ -85,27 +85,27 @@ EOS
   end
 
   def test_that_strict_flag_works
-    rd = RDiscount.new("foo_bar_baz", :strict)
+    rd = RDiscount.new("foo_bar_baz", :MKD_NOPANTS, :MKD_STRICT)
     assert_equal "<p>foo<em>bar</em>baz</p>\n", rd.to_html
   end
 
   def test_that_autolink_flag_works
-    rd = RDiscount.new("http://github.com/rtomayko/rdiscount", :autolink)
+    rd = RDiscount.new("http://github.com/rtomayko/rdiscount", :MKD_NOPANTS, :MKD_AUTOLINK)
     assert_equal "<p><a href=\"http://github.com/rtomayko/rdiscount\">http://github.com/rtomayko/rdiscount</a></p>\n", rd.to_html
   end
 
   def test_that_safelink_flag_works
-    rd = RDiscount.new("[IRC](irc://chat.freenode.org/#freenode)", :safelink)
+    rd = RDiscount.new("[IRC](irc://chat.freenode.org/#freenode)", :MKD_NOPANTS, :MKD_SAFELINK)
     assert_equal "<p>[IRC](irc://chat.freenode.org/#freenode)</p>\n", rd.to_html
   end
 
   def test_that_no_pseudo_protocols_flag_works
-    rd = RDiscount.new("[foo](id:bar)", :no_pseudo_protocols)
+    rd = RDiscount.new("[foo](id:bar)", :MKD_NOPANTS, :MKD_NO_EXT)
     assert_equal "<p>[foo](id:bar)</p>\n", rd.to_html
   end
 
   def test_that_tags_can_have_dashes_and_underscores
-    rd = RDiscount.new("foo <asdf-qwerty>bar</asdf-qwerty> and <a_b>baz</a_b>")
+    rd = RDiscount.new("foo <asdf-qwerty>bar</asdf-qwerty> and <a_b>baz</a_b>", :MKD_NOPANTS)
     assert_equal "<p>foo <asdf-qwerty>bar</asdf-qwerty> and <a_b>baz</a_b></p>\n", rd.to_html
   end
 end


### PR DESCRIPTION
These commits make RDiscount a thinner layer over the Discount library.  They introduce the following backwards-incompatible changes:
- SmartyPants is now enabled by default, because that's the default behavior of the Discount library.
- Many attribute accessors in the `RDiscount` class were replaced by a single `RDiscount#flags` accessor which just contains the raw integer bit flags that are passed directly to the underlying Discount library.
- Integer bit masks in the Discount library are exported (using the same names) as constants in the `RDiscount` class.
- An environment variable `RDISCOUNT_EXTENSIONS` allows people to choose the set of RDiscount extensions and Discount flags that they want to enable at the command-line.

Cheers.
