### PR TITLE
Use Kramdown on JRuby

### DIFF
--- a/lib/rdiscount-kramdown.rb
+++ b/lib/rdiscount-kramdown.rb
@@ -1,0 +1,28 @@
+require 'kramdown'
+
+class RDiscount
+  class ::Kramdown::Converter::Rdiscounthtml < Kramdown::Converter::Html
+    def initialize(root, options)
+      super
+      self.indent = 0
+    end
+  end
+  
+  def to_html(*)
+    text = self.text
+    html = Kramdown::Document.new(text).to_rdiscounthtml
+    if text.respond_to? :encoding
+      html.force_encoding text.encoding
+    end
+    html
+  end
+  
+  def toc_content(*)
+    text = self.text
+    html = Kramdown::Document.new(text).to_toc
+    if text.respond_to? :encoding
+      html.force_encoding text.encoding
+    end
+    html
+  end
+end

--- a/lib/rdiscount.rb
+++ b/lib/rdiscount.rb
@@ -93,4 +93,9 @@ end
 
 Markdown = RDiscount unless defined? Markdown
 
-require 'rdiscount.so'
+begin
+  require 'rdiscount.so'
+rescue LoadError
+  # fall back on kramdown
+  require 'rdiscount-kramdown'
+end

--- a/rdiscount-java.gemspec
+++ b/rdiscount-java.gemspec
@@ -1,0 +1,37 @@
+Gem::Specification.new do |s|
+  s.name = 'rdiscount'
+  s.version = '1.6.8'
+  s.summary = "Fast Implementation of Gruber's Markdown in C"
+  s.date = '2011-01-25'
+  s.email = 'rtomayko@gmail.com'
+  s.homepage = 'http://github.com/rtomayko/rdiscount'
+  s.authors = ["Ryan Tomayko", "David Loren Parsons", "Andrew White"]
+  # = MANIFEST =
+  s.files = %w[
+    BUILDING
+    COPYING
+    README.markdown
+    Rakefile
+    bin/rdiscount
+    discount
+    lib/markdown.rb
+    lib/rdiscount.rb
+    lib/rdiscount-kramdown.rb
+    man/markdown.7
+    man/rdiscount.1
+    man/rdiscount.1.ronn
+    rdiscount-java.gemspec
+    test/benchmark.rb
+    test/benchmark.txt
+    test/markdown_test.rb
+    test/rdiscount_test.rb
+  ]
+  # = MANIFEST =
+  s.test_files = ["test/markdown_test.rb", "test/rdiscount_test.rb"]
+  s.extra_rdoc_files = ["COPYING"]
+  s.executables = ["rdiscount"]
+  s.require_paths = ["lib"]
+  s.rubyforge_project = 'wink'
+  s.add_dependency 'kramdown', '>= 0.13.5'
+  s.platform = "java"
+end


### PR DESCRIPTION
There's a number of libraries that depend on rdiscount directly, and since there's no "markdown" meta-gem like there is for json, this commit makes a 'java' version of the rdiscount gem that just uses the pure-Ruby Kramdown library.

The rdiscount tests have very specific requirements about HTML formatting, so I wan't quite able to get everything to pass; markdown_test.rb fails 7 tests, and rdiscount_test.rb appears to hang (possibly a JRuby bug). But the output from Kramdown is usually correct "in spirit" if not exactly what rdiscount would produce.
