### PR TITLE
Don't read free'd memory when switching locales

### DIFF
--- a/ext/rdiscount.c
+++ b/ext/rdiscount.c
@@ -27,7 +27,10 @@ rb_rdiscount_to_html(int argc, VALUE *argv, VALUE self)
      * of at least 21 bits).
      */
     char *old_locale = setlocale(LC_CTYPE, NULL);
-    setlocale(LC_CTYPE, "C");   // ASCII (and passthru characters > 127)
+    if(old_locale) {
+        old_locale = strdup(old_locale);
+        setlocale(LC_CTYPE, "C");   // ASCII (and passthru characters > 127)
+    }
 
     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
 
@@ -41,7 +44,10 @@ rb_rdiscount_to_html(int argc, VALUE *argv, VALUE self)
     }
     mkd_cleanup(doc);
 
-    setlocale(LC_CTYPE, old_locale);
+    if(old_locale) {
+        setlocale(LC_CTYPE, old_locale);
+        free(old_locale);
+    }
 
     /* force the input encoding */
     if ( rb_respond_to(text, rb_intern("encoding")) ) {


### PR DESCRIPTION
According to valgrind, setlocale actually frees the buffer that is
returned when running setlocale() with a NULL argument to retrieve the
current locale.

This means it's needed to duplicate the retrieved locale and free it
after putting it back.

This is how valgrind reports this issue:

==27152== Invalid read of size 1
==27152==    at 0x4C2CBC1: __GI_strcmp (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27152==    by 0x5ED2430: setlocale (setlocale.c:210)
==27152==    by 0xECB241B: rb_rdiscount_to_html (rdiscount.c:44)
...

==27152==  Address 0x63b7d50 is 0 bytes inside a block of size 6 free'd
==27152==    at 0x4C2A82E: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==27152==    by 0x5ED256A: setlocale (setlocale.c:173)
==27152==    by 0xECB23CC: rb_rdiscount_to_html (rdiscount.c:30)
...
