### PR TITLE
Copy result of setlocale(..., NULL)

### DIFF
--- a/ext/rdiscount.c
+++ b/ext/rdiscount.c
@@ -26,7 +26,7 @@ rb_rdiscount_to_html(int argc, VALUE *argv, VALUE self)
      * functions since they expect 8-bit codepoints (and UTF-8 has codepoints
      * of at least 21 bits).
      */
-    char *old_locale = setlocale(LC_CTYPE, NULL);
+    char *old_locale = strdup(setlocale(LC_CTYPE, NULL));
     setlocale(LC_CTYPE, "C");   // ASCII (and passthru characters > 127)
 
     MMIOT *doc = mkd_string(RSTRING_PTR(text), RSTRING_LEN(text), flags);
@@ -42,6 +42,7 @@ rb_rdiscount_to_html(int argc, VALUE *argv, VALUE self)
     mkd_cleanup(doc);
 
     setlocale(LC_CTYPE, old_locale);
+    free(old_locale);
 
     /* force the input encoding */
     if ( rb_respond_to(text, rb_intern("encoding")) ) {


### PR DESCRIPTION
...since it points to an internal buffer that is freed upon the subsequent setlocale(..., "C") call.

Bug discovered by @dbussink using Valgrind.
