### PR TITLE
Use RbConfig instead of Config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task :default => :test
 # Ruby Extension
 # ==========================================================
 
-DLEXT = Config::MAKEFILE_CONFIG['DLEXT']
+DLEXT = RbConfig::MAKEFILE_CONFIG['DLEXT']
 RUBYDIGEST = Digest::MD5.hexdigest(`ruby --version`)
 
 file "ext/ruby-#{RUBYDIGEST}" do |f|


### PR DESCRIPTION
The Config module is depricated in favor of RbConfig, and as of Ruby 2.2 no longer exists (it used to print a warning). It [appears](http://ruby-doc.org/stdlib-1.9.2/libdoc/rubygems/rdoc/RbConfig.html) that RbConfig exists since at least Ruby 1.9.2, so all versions of Ruby supported by Rdiscount should be fine with this change.