### PR TITLE
Bugfix filter_styles 

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -17,7 +17,7 @@ grabbing the discount submodule into the root of the project and then running
 the rake gather task to copy discount source files into the ext/ directory:
 
     $ git submodule update --init
-    Submodule 'discount' (git://github.com/davidfstr/discount.git) registered for path 'discount'
+    Submodule 'discount' (git@github.com:Orc/discount.git) registered for path 'discount'
     Cloning into discount...
     $ cd discount
     $ ./configure.sh

--- a/ext/rdiscount.c
+++ b/ext/rdiscount.c
@@ -18,6 +18,7 @@ typedef struct {
  * - MKD_FENCEDCODE: Always set. (For compatibility with RDiscount 2.1.8 and earlier.)
  * - MKD_GITHUBTAGS: Always set. (For compatibility with RDiscount 2.1.8 and earlier.)
  * - MKD_NOPANTS: Set unless the "smart" accessor returns true.
+ * - MKD_NOSTYLE: Set unless the "filter_styles" accessor returns true.
  * 
  * See rb_rdiscount__get_flags() for the detailed implementation.
  */
@@ -52,6 +53,11 @@ int rb_rdiscount__get_flags(VALUE ruby_obj)
     /* The "smart" accessor turns OFF the MKD_NOPANTS flag. */
     if ( rb_funcall(ruby_obj, rb_intern("smart"), 0) != Qtrue ) {
         flags = flags | MKD_NOPANTS;
+    }
+
+    /* The "filter_styles" accessor turns OFF the MKD_NOSTYLE flag. */
+    if ( rb_funcall(ruby_obj, rb_intern("filter_styles"), 0) != Qtrue ) {
+        flags = flags | MKD_NOSTYLE;
     }
     
     /* Handle standard flags declared in ACCESSOR_2_FLAG */

--- a/test/rdiscount_test.rb
+++ b/test/rdiscount_test.rb
@@ -183,10 +183,25 @@ EOS
   end
   
   def test_that_style_tag_is_not_filtered_by_default
-    rd = RDiscount.new("Hello<style>p { margin: 5px; }</style>")
-    assert_equal "<p>Hello<style>p { margin: 5px; }</style></p>\n", rd.to_html
+    rd = RDiscount.new(<<EOS)
+Hello
+<style>
+p { margin: 5px; }
+</style>
+EOS
+    assert_equal "<p>Hello</p>\n\n<style>\np { margin: 5px; }\n</style>\n\n", rd.to_html
   end
   
+  def test_that_style_tag_is_filtered_with_flag
+    rd = RDiscount.new(<<EOS, :filter_styles)
+Hello
+<style>
+p { margin: 5px; }
+</style>
+EOS
+    assert_equal "<p>Hello</p>\n\n\n", rd.to_html
+  end
+
   def test_that_tables_can_have_leading_and_trailing_pipes
     rd = RDiscount.new(<<EOS)
 | A | B |


### PR DESCRIPTION
This allows by default to use `<style>` tags in markdown.
The tests did not fail because the upstream lib does
not filter inline `<style>` tags. (Probably a bug)

Fix the filter_styles flag to actually filter styles.

Fix https://github.com/davidfstr/rdiscount/issues/149